### PR TITLE
add alchemy as 7677 compatible provider

### DIFF
--- a/docs/pages/ecosystem/paymasters.mdx
+++ b/docs/pages/ecosystem/paymasters.mdx
@@ -4,3 +4,4 @@
 * [Pimlico](https://docs.pimlico.io)
 * [ZeroDev](https://docs.zerodev.app)
 * [Biconomy](https://docs.biconomy.io/Paymaster/7677/)
+* [Alchemy](https://docs.alchemy.com/reference/paymaster-api-endpoints)


### PR DESCRIPTION
Alchemy paymaster is now 7677 compliant https://docs.alchemy.com/reference/paymaster-api-endpoints